### PR TITLE
BAH-2566 | added proxy config for custom internal server error message

### DIFF
--- a/bahmni-proxy/Dockerfile
+++ b/bahmni-proxy/Dockerfile
@@ -11,6 +11,7 @@ COPY resources/bahmni-logo.png /usr/local/apache2/htdocs/bahmni-logo.png
 COPY resources/favicon.png /usr/local/apache2/htdocs/favicon.png
 COPY resources/maintenance.html /usr/local/apache2/htdocs/maintenance.html
 COPY resources/unauthorized.html /usr/local/apache2/htdocs/unauthorized.html
+COPY resources/internalError.html /usr/local/apache2/htdocs/internalError.html
 COPY resources/style.css /usr/local/apache2/htdocs/style.css
 COPY resources/src.jpeg /usr/local/apache2/htdocs/src.jpeg
 RUN mkdir /var/cache/mod_proxy

--- a/bahmni-proxy/resources/bahmni-proxy.conf
+++ b/bahmni-proxy/resources/bahmni-proxy.conf
@@ -185,6 +185,9 @@ Listen 443
     RewriteRule ^.*$ /maintenance.html [R=503,L]
     ErrorDocument 503 /maintenance.html
 
+    ProxyErrorOverride on
+    ErrorDocument 500 /internalError.html
+
     <Files ~ "\.(cgi|shtml|phtml|php3?)$">
     SSLOptions +StdEnvVars
     </Files>

--- a/bahmni-proxy/resources/internalError.html
+++ b/bahmni-proxy/resources/internalError.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>500 Internal Server Error</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<link rel="stylesheet" href="style.css" />
+	</head>
+	<body>
+		<img src="/bahmni-logo.png" alt="Bahmni" width="200" />
+		<h1>Internal Server Error</h1>
+		<p>The server encountered an internal error or
+			misconfiguration and was unable to complete
+			your request.</p>
+		<p>Please contact the server administrator to inform them of the time this error occurred,
+			and the actions you performed just before this error.</p>
+		<p>More information about this error may be available
+			in the server error log.</p>
+	</body>
+</html>


### PR DESCRIPTION
This will override the default tomcat stack-trace being shown for 500 status code with a custom message