### PR TITLE
BAH-2407 | Fix. Proxy Error override only for 5xx codes

### DIFF
--- a/bahmni-proxy/resources/bahmni-proxy.conf
+++ b/bahmni-proxy/resources/bahmni-proxy.conf
@@ -52,11 +52,11 @@ ProxyPassReverse /dcm4chee-web3 http://dcm4chee:8055/dcm4chee-web3
 ProxyPass /oviyam2 http://dcm4chee:8055/oviyam2
 ProxyPassReverse /oviyam2 http://dcm4chee:8055/oviyam2
 
-#Atomfeed-console 
+#Atomfeed-console
 ProxyPass /atomfeed-console http://atomfeed-console:9080/atomfeed-console
 ProxyPassReverse /atomfeed-console http://atomfeed-console:9080/atomfeed-console
 
-#Metabase 
+#Metabase
 ProxyPass /metabase http://metabase:3000
 ProxyPassReverse /metabase http://metabase:3000
 
@@ -153,14 +153,14 @@ Listen 443
     RewriteCond %{REQUEST_URI} ^/openmrs/*
     RewriteCond %{HTTP_COOKIE} ^.*JSESSIONID=([^;]+)
     RewriteRule ^.*$ - [CO=reporting_session:%1:%{HTTP_HOST}:86400:/:true:true]
-    
+
     ProxyPreserveHost On
-    
+
     #   SSL Protocol support:
     # List the enable protocol levels with which clients will be able to
     # connect.  Disable SSLv2 access by default:
     #SSLProtocol all -SSLv2
-    SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1 
+    SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
 
     #   SSL Cipher Suite:
     # List the ciphers that the client is permitted to negotiate.
@@ -189,7 +189,7 @@ Listen 443
     RewriteRule ^.*$ /maintenance.html [R=503,L]
     ErrorDocument 503 /maintenance.html
 
-    ProxyErrorOverride on
+    ProxyErrorOverride on 500 501 502
     ErrorDocument 500 /internalError.html
 
     <Files ~ "\.(cgi|shtml|phtml|php3?)$">


### PR DESCRIPTION
Fixing ProxyErrorOverride only for 500, 501,502 responses. Without this all the error requests including 401,403 gets overridden due to which some cookies on the client side are not getting invalidated as expected.