### PR TITLE
BAH-2782 | Bahmni-lite env setup through docker-compose

### DIFF
--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -1,0 +1,57 @@
+name: Deploy to Bahmni Lite Docker Env
+on:
+  push:
+    branches:
+      - master
+      - BAH-2782
+      - 'release-*'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+    paths:
+      - 'bahmni-proxy/**'
+      - '.github/workflows/bahmni_lite_docker_env.yaml'
+  repository_dispatch:
+    types: [ "bahmni-helm-publish-event" ]
+  workflow_dispatch:
+    inputs:
+      stop_options:
+        description: 'Choose the option to stop application. "Simple" does not remove volumes, down-v removes the volumes'
+        required: true
+        type: choice
+        default: simple
+        options:
+          - simple
+          - down-v
+
+jobs:
+  deploy:
+    name: Deploy to Remote Instance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.BAHMNI_AWS_ID }}
+          aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
+          aws-region: ap-south-1
+          role-to-assume: arn:aws:iam::863324974761:role/BahmniInfraAdminRoleForIAMUsers
+          role-duration-seconds: 1200  # 20 mins
+          role-session-name: BahmniInfraAdminSession
+      - name: Create/Update Containers
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=bahmni-lite-docker" "Name=instance-state-name,Values=running" --query "Reservations[].Instances[].InstanceId" --output text)
+          aws ssm send-command \
+          --instance-ids "$INSTANCE_ID" \
+          --document-name "AWS-RunShellScript" \
+          --comment "Check Running Containers" \
+          --parameters '{
+              "commands": [
+                "docker compose --profile bahmni-lite pull",
+                "docker compose --profile bahmni-lite up -d"
+              ],
+              "workingDirectory": [
+                "/home/ubuntu/bahmni-docker/bahmni-lite"
+            ]
+          }' | jq '.Command | {CommandId: .CommandId, Parameters: .Parameters, Status: .Status}'
+

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - 'bahmni-proxy/**'
+      - 'bahmni-lite/**'
       - '.github/workflows/bahmni_lite_docker_env.yaml'
       - '.github/workflows/proxy_image_build_publish.yml'
   repository_dispatch:

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -4,12 +4,10 @@ on:
     branches:
       - master
       - BAH-2782
-      - 'release-*'
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
     paths:
       - 'bahmni-proxy/**'
       - '.github/workflows/bahmni_lite_docker_env.yaml'
+      - '.github/workflows/proxy_image_build_publish.yml'
   repository_dispatch:
     types: [ "bahmni-helm-publish-event" ]
   workflow_dispatch:

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - BAH-2782
     paths:
       - 'bahmni-proxy/**'
       - '.github/workflows/bahmni_lite_docker_env.yaml'

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -43,9 +43,9 @@ jobs:
       - name: Create/Update Containers
         run: |
           if [ "$UPDATE_BAHMNI_OPTION" == "update_without_removing_volumes" ]; then
-            command="docker compose --profile bahmni-lite up -d"
+            command="docker compose up -d"
           elif [ "$UPDATE_BAHMNI_OPTION" == "update_and_remove_volumes" ]; then
-            command="docker compose --profile bahmni-lite down -v && docker compose --profile bahmni-lite up -d"
+            command="docker compose down -v && docker compose up -d"
           fi
           
           INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=bahmni-lite-docker" "Name=instance-state-name,Values=running" --query "Reservations[].Instances[].InstanceId" --output text)
@@ -60,7 +60,7 @@ jobs:
             --parameters '{
                 "commands": [
                   "git pull -r",
-                  "docker compose --profile bahmni-lite pull",
+                  "docker compose pull",
                   "'"$command"'",
                   "docker image prune -f"
                 ],

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -14,14 +14,16 @@ on:
     types: [ "bahmni-helm-publish-event" ]
   workflow_dispatch:
     inputs:
-      stop_options:
-        description: 'Choose the option to stop application. "Simple" does not remove volumes, down-v removes the volumes'
+      update_bahmni_option:
+        description: 'Choose the option to update Bahmni. "Update without removing volumes" or "Update and remove volumes"'
         required: true
         type: choice
-        default: simple
+        default: update_without_removing_volumes
         options:
-          - simple
-          - down-v
+          - update_without_removing_volumes
+          - update_and_remove_volumes
+env:
+  UPDATE_BAHMNI_OPTION: ${{ github.event.inputs.update_bahmni_option || 'update_without_removing_volumes'}}
 
 jobs:
   deploy:
@@ -40,19 +42,29 @@ jobs:
           role-session-name: BahmniInfraAdminSession
       - name: Create/Update Containers
         run: |
+          if [ "$UPDATE_BAHMNI_OPTION" == "update_without_removing_volumes" ]; then
+            command="docker compose --profile bahmni-lite up -d"
+          elif [ "$UPDATE_BAHMNI_OPTION" == "update_and_remove_volumes" ]; then
+            command="docker compose --profile bahmni-lite down -v && docker compose --profile bahmni-lite up -d"
+          fi
+          
           INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=bahmni-lite-docker" "Name=instance-state-name,Values=running" --query "Reservations[].Instances[].InstanceId" --output text)
-          aws ssm send-command \
-          --instance-ids "$INSTANCE_ID" \
-          --document-name "AWS-RunShellScript" \
-          --comment "Check Running Containers" \
-          --parameters '{
-              "commands": [
-                "docker compose --profile bahmni-lite pull",
-                "docker compose --profile bahmni-lite up -d",
-                "docker image prune -f"
-              ],
-              "workingDirectory": [
-                "/home/ubuntu/bahmni-docker/bahmni-lite"
-            ]
-          }' | jq '.Command | {CommandId: .CommandId, Parameters: .Parameters, Status: .Status}'
-
+          
+          if [ -z "$INSTANCE_ID" ]; then
+            echo "Instance not running"
+          else
+            aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Update running containers" \
+            --parameters '{
+                "commands": [
+                  "docker compose --profile bahmni-lite pull",
+                  "'"$command"'",
+                  "docker image prune -f"
+                ],
+                "workingDirectory": [
+                  "/home/ubuntu/bahmni-docker/bahmni-lite"
+              ]
+            }' | jq '.Command | {CommandId: .CommandId, Parameters: .Parameters, Status: .Status}'
+          fi

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -59,6 +59,7 @@ jobs:
             --comment "Update running containers" \
             --parameters '{
                 "commands": [
+                  "git pull -r",
                   "docker compose --profile bahmni-lite pull",
                   "'"$command"'",
                   "docker image prune -f"

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -48,7 +48,8 @@ jobs:
           --parameters '{
               "commands": [
                 "docker compose --profile bahmni-lite pull",
-                "docker compose --profile bahmni-lite up -d"
+                "docker compose --profile bahmni-lite up -d",
+                "docker image prune -f"
               ],
               "workingDirectory": [
                 "/home/ubuntu/bahmni-docker/bahmni-lite"

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -9,7 +9,9 @@ on:
       - '.github/workflows/bahmni_lite_docker_env.yaml'
       - '.github/workflows/proxy_image_build_publish.yml'
   repository_dispatch:
-    types: [ "bahmni-helm-publish-event" ]
+    types:
+      - bahmni-helm-publish-event
+      - openmrs-db-publish-event
   workflow_dispatch:
     inputs:
       update_bahmni_option:

--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -37,7 +37,7 @@ jobs:
           aws-access-key-id: ${{ secrets.BAHMNI_AWS_ID }}
           aws-secret-access-key: ${{ secrets.BAHMNI_AWS_SECRET }}
           aws-region: ap-south-1
-          role-to-assume: arn:aws:iam::863324974761:role/BahmniInfraAdminRoleForIAMUsers
+          role-to-assume: ${{ secrets.BAHMNI_INFRA_ADMIN_ROLE }}
           role-duration-seconds: 1200  # 20 mins
           role-session-name: BahmniInfraAdminSession
       - name: Create/Update Containers

--- a/.github/workflows/proxy_image_build_publish.yml
+++ b/.github/workflows/proxy_image_build_publish.yml
@@ -3,12 +3,13 @@ on:
   push:
     branches:
       - master
+      - BAH-2782
       - 'release-*'
     tags:
         - '[0-9]+.[0-9]+.[0-9]+'
-    paths:
-      - 'bahmni-proxy/**'
-      - '.github/workflows/proxy_image_build_publish.yml'
+#    paths:
+#      - 'bahmni-proxy/**'
+#      - '.github/workflows/proxy_image_build_publish.yml'
 
 jobs:
   docker-build-publish:
@@ -39,4 +40,3 @@ jobs:
           no-cache: true
           push: true
           tags: bahmni/proxy:${{env.ARTIFACT_VERSION}},bahmni/proxy:latest
-

--- a/.github/workflows/proxy_image_build_publish.yml
+++ b/.github/workflows/proxy_image_build_publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - BAH-2782
       - 'release-*'
     tags:
         - '[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/proxy_image_build_publish.yml
+++ b/.github/workflows/proxy_image_build_publish.yml
@@ -3,13 +3,12 @@ on:
   push:
     branches:
       - master
-      - BAH-2782
       - 'release-*'
     tags:
         - '[0-9]+.[0-9]+.[0-9]+'
-#    paths:
-#      - 'bahmni-proxy/**'
-#      - '.github/workflows/proxy_image_build_publish.yml'
+    paths:
+      - 'bahmni-proxy/**'
+      - '.github/workflows/proxy_image_build_publish.yml'
 
 jobs:
   docker-build-publish:

--- a/.github/workflows/proxy_image_build_publish.yml
+++ b/.github/workflows/proxy_image_build_publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - BAH-2782
       - 'release-*'
     tags:
         - '[0-9]+.[0-9]+.[0-9]+'

--- a/bahmni-proxy/resources/bahmni-proxy.conf
+++ b/bahmni-proxy/resources/bahmni-proxy.conf
@@ -159,6 +159,11 @@ Listen 443
     RewriteCond %{HTTP_HOST} ^payments-[^.]+
     RewriteRule (.*) http://crater-nginx$1 [P]
 
+    # This configuration redirects any request with a host name starting with "erp-"
+    # to the odoo container, preserving the requested URL path.
+    RewriteCond %{HTTP_HOST} ^erp-[^.]+
+    RewriteRule (.*) http://odoo:8069$1 [P]
+
     ProxyPreserveHost On
 
     #   SSL Protocol support:

--- a/bahmni-proxy/resources/bahmni-proxy.conf
+++ b/bahmni-proxy/resources/bahmni-proxy.conf
@@ -154,6 +154,11 @@ Listen 443
     RewriteCond %{HTTP_COOKIE} ^.*JSESSIONID=([^;]+)
     RewriteRule ^.*$ - [CO=reporting_session:%1:%{HTTP_HOST}:86400:/:true:true]
 
+    # This configuration redirects any request with a host name starting with "payments-"
+    # to the crater-nginx container, preserving the requested URL path.
+    RewriteCond %{HTTP_HOST} ^payments-[^.]+
+    RewriteRule (.*) http://crater-nginx$1 [P]
+
     ProxyPreserveHost On
 
     #   SSL Protocol support:


### PR DESCRIPTION
- This PR adds a workflow to  enable auto deployment to  Bahmni on AWS instances running on Docker Compose. 
- This PR also adds two rewrite rules to the proxy image, allowing for seamless routing of requests from domains with the "payments-" or "erp-" prefix. 