### PR TITLE
BAH-2918 | Remove unused volumes and ports from docker compose

### DIFF
--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -67,7 +67,6 @@ services:
       - '8080:8080'
       # - ${OMRS_DEV_DEBUG_PORT}:${OMRS_DEV_DEBUG_PORT}
     volumes:
-      - 'openmrs-data:/openmrs/data/modules'
       - "${CONFIG_VOLUME:?}:/etc/bahmni_config/:ro"
       # - "${BAHMNI_OPENMRS_MODULES_PATH:?}/:/openmrs/data/modules/"
       - 'bahmni-patient-images:/home/bahmni/patient_images'

--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -63,8 +63,7 @@ services:
       MAIL_USER: ${MAIL_USER}
       MAIL_PASSWORD: ${MAIL_PASSWORD}
       OMRS_DOCKER_ENV: ${OPENMRS_DOCKER_ENV}
-    ports:
-      - '8080:8080'
+    #ports:
       # - ${OMRS_DEV_DEBUG_PORT}:${OMRS_DEV_DEBUG_PORT}
     volumes:
       - "${CONFIG_VOLUME:?}:/etc/bahmni_config/:ro"

--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -19,9 +19,8 @@ services:
 
   proxy:
     image: 'bahmni/proxy:${PROXY_IMAGE_TAG:?}'
-    volumes:
+    #volumes:
       # - ${CERTIFICATE_PATH}:/etc/tls
-      - 'bahmni-patient-images:/home/bahmni/patient_images'
     ports:
       - '80:80'
       - '443:443'
@@ -182,7 +181,7 @@ services:
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST:?}
       OPENMRS_DB_NAME: ${OPENMRS_DB_NAME:?}
       OPENMRS_DB_USERNAME: ${OPENMRS_DB_USERNAME:?}
-      OPENMRS_DB_PASSWORD: ${OPENMRS_DB_PASSWORD:?}  
+      OPENMRS_DB_PASSWORD: ${OPENMRS_DB_PASSWORD:?}
       MART_DB_HOST: ${MART_DB_HOST:?}
       MART_DB_NAME: ${MART_DB_NAME:?}
       MART_DB_USERNAME: ${MART_DB_USERNAME:?}
@@ -201,8 +200,8 @@ services:
       - 'mart-data:/var/lib/postgresql/data'
     ports:
      - 5435:5432
-  
-  mart: 
+
+  mart:
     image: bahmni/bahmni-mart:${BAHMNI_MART_IMAGE_TAG:?}
     profiles: ["bahmni-mart"]
     environment:

--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -35,9 +35,6 @@ services:
   bahmni-lab:
     profiles: ["lab-lite","emr","bahmni-lite"]
     image: 'bahmni/bahmni-lab:${BAHMNI_LAB_IMAGE_TAG:?}'
-    ports:
-      - '8090:80'
-      - '8443:443'
     logging: *log-config
 
   openmrs:
@@ -92,8 +89,6 @@ services:
       MYSQL_DATABASE: ${OPENMRS_DB_NAME:?}
       MYSQL_USER: ${OPENMRS_DB_USERNAME:?}
       MYSQL_PASSWORD: ${OPENMRS_DB_PASSWORD:?}
-    ports:
-      - '3306:3306'
     volumes:
       - 'openmrsdbdata:/var/lib/mysql'
       - 'configuration_checksums:/configuration_checksums'
@@ -148,8 +143,7 @@ services:
       MYSQL_PASSWORD: ${CRATER_DB_PASSWORD:?}
       MYSQL_DATABASE: ${CRATER_DB_DATABASE:?}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?}
-    ports:
-      - '33006:3306'
+
 
   metabasedb:
     image: postgres:${METABASE_POSTGRES_IMAGE_TAG:?}
@@ -161,8 +155,7 @@ services:
       POSTGRES_PASSWORD: ${METABASE_DB_PASSWORD:?}
     volumes:
       - 'metabase-data:/var/lib/postgresql/data'
-    ports:
-     - 5430:5432
+
 
   metabase:
     image: bahmni/bahmni-metabase:${METABASE_IMAGE_TAG:?}
@@ -198,8 +191,7 @@ services:
       POSTGRES_PASSWORD: ${MART_DB_PASSWORD:?}
     volumes:
       - 'mart-data:/var/lib/postgresql/data'
-    ports:
-     - 5435:5432
+
 
   mart:
     image: bahmni/bahmni-mart:${BAHMNI_MART_IMAGE_TAG:?}
@@ -274,8 +266,6 @@ services:
 
   patient-documents:
     image: 'bahmni/patient-documents:${PATIENT_DOCUMENTS_TAG:?}'
-    ports:
-      - '8099:80'
     profiles: ["emr","bahmni-lite"]
     volumes:
       - 'bahmni-document-images:/usr/share/nginx/html/document_images'

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -157,8 +157,7 @@ services:
       MAIL_FROM: ${MAIL_FROM}
       MAIL_USER: ${MAIL_USER}
       MAIL_PASSWORD: ${MAIL_PASSWORD}
-    ports:
-      - '8080:8080'
+    #ports:
       # - ${OMRS_DEV_DEBUG_PORT}:${OMRS_DEV_DEBUG_PORT}
     volumes:
       - "${CONFIG_VOLUME:?}:/etc/bahmni_config/:ro"

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -37,8 +37,6 @@ services:
   openelis:
     profiles: ["openelis","bahmni-standard"]
     image: 'bahmni/openelis:${OPENELIS_IMAGE_TAG:?[ERROR]}'
-    ports:
-      - '8052:8052'
     volumes:
       - "${CONFIG_VOLUME:?}:/etc/bahmni_config/:ro"
       - "bahmni-lab-results:/home/bahmni/uploaded_results"
@@ -57,8 +55,6 @@ services:
   openelisdb:
     profiles: ["openelis","bahmni-standard"]
     image: 'bahmni/openelis-db:${OPENELIS_DB_IMAGE_TAG:?[ERROR]}'
-    ports:
-      - '5432:5432'
     volumes:
       - '${OPENELIS_DB_DUMP_PATH}:/resources/db-dump'
       - 'openelisdbdata:/var/lib/postgresql/data'
@@ -95,8 +91,6 @@ services:
   odoodb:
     profiles: ["odoo","bahmni-standard"]
     image: 'bahmni/odoo-10-db:${ODOO_DB_IMAGE_TAG:?[ERROR]}'
-    ports:
-      - '5431:5432'
     volumes:
       - '${ODOO_DB_DUMP_PATH}:/resources/db-dump'
       - 'odoodbdata:/var/lib/postgresql/data'
@@ -186,8 +180,6 @@ services:
       MYSQL_DATABASE: ${OPENMRS_DB_NAME:?}
       MYSQL_USER: ${OPENMRS_DB_USERNAME:?}
       MYSQL_PASSWORD: ${OPENMRS_DB_PASSWORD:?}
-    ports:
-      - '3306:3306'
     volumes:
       - 'openmrsdbdata:/var/lib/mysql'
     logging: *log-config
@@ -202,8 +194,6 @@ services:
       POSTGRES_PASSWORD: ${METABASE_DB_PASSWORD:?}
     volumes:
       - 'metabase-data:/var/lib/postgresql/data'
-    ports:
-     - 5430:5432
 
   metabase:
     image: bahmni/bahmni-metabase:${METABASE_IMAGE_TAG:?}
@@ -239,8 +229,6 @@ services:
       POSTGRES_PASSWORD: ${MART_DB_PASSWORD:?}
     volumes:
       - 'mart-data:/var/lib/postgresql/data'
-    ports:
-     - 5435:5432
 
   mart:
     image: bahmni/bahmni-mart:${BAHMNI_MART_IMAGE_TAG:?}
@@ -319,8 +307,6 @@ services:
 
   patient-documents:
     image: 'bahmni/patient-documents:${PATIENT_DOCUMENTS_TAG:?}'
-    ports:
-      - '8099:80'
     profiles: ["emr","bahmni-standard"]
     volumes:
       - 'bahmni-document-images:/usr/share/nginx/html/document_images'

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -161,7 +161,6 @@ services:
       - '8080:8080'
       # - ${OMRS_DEV_DEBUG_PORT}:${OMRS_DEV_DEBUG_PORT}
     volumes:
-      - 'openmrs-data:/openmrs/data/modules'
       - "${CONFIG_VOLUME:?}:/etc/bahmni_config/:ro"
       # - "${BAHMNI_OPENMRS_MODULES_PATH:?}/:/openmrs/data/modules/"
       - 'bahmni-patient-images:/home/bahmni/patient_images'

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     image: 'bahmni/proxy:${PROXY_IMAGE_TAG:?}'
     volumes:
       # - ${CERTIFICATE_PATH}:/etc/tls
-      - 'bahmni-patient-images:/home/bahmni/patient_images'
       - 'bahmni-lab-results:/usr/local/apache2/htdocs/uploaded_results'
     ports:
       - '80:80'
@@ -223,7 +222,7 @@ services:
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST:?}
       OPENMRS_DB_NAME: ${OPENMRS_DB_NAME:?}
       OPENMRS_DB_USERNAME: ${OPENMRS_DB_USERNAME:?}
-      OPENMRS_DB_PASSWORD: ${OPENMRS_DB_PASSWORD:?}  
+      OPENMRS_DB_PASSWORD: ${OPENMRS_DB_PASSWORD:?}
       MART_DB_HOST: ${MART_DB_HOST:?}
       MART_DB_NAME: ${MART_DB_NAME:?}
       MART_DB_USERNAME: ${MART_DB_USERNAME:?}
@@ -242,8 +241,8 @@ services:
       - 'mart-data:/var/lib/postgresql/data'
     ports:
      - 5435:5432
-  
-  mart: 
+
+  mart:
     image: bahmni/bahmni-mart:${BAHMNI_MART_IMAGE_TAG:?}
     profiles: ["bahmni-mart"]
     environment:


### PR DESCRIPTION
JIRA Card --> https://bahmni.atlassian.net/browse/BAH-2918

- Patient images are not needed to be mounted with proxy container as they are served directly by an OMRS rest API.

- Modules directory of the OMRS container should not be mounted as this would cause the modules to be persisted and updating the image tag would not bring in the latest OMODs

- Port mapping of database containers can be removed, so that they don’t get mapped on the host machine which reduces the attack possibilities