### PR TITLE
Rahul | BAH-3005 | Setting Default Timezone As Asia/Kolkata

### DIFF
--- a/bahmni-lite/.env
+++ b/bahmni-lite/.env
@@ -2,7 +2,7 @@
 COMPOSE_PROFILES=emr
 
 # Environment variable to set the timezone for the containers
-TZ=UTC
+TZ=Asia/Kolkata
 
 # Host-Port Mappings, credentials for Atomfeed Sync across various services. Defaults to services running in docker.
 OPENMRS_HOST=openmrs


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

In this PR, we have added the TZ environment variable to all the services (with tzdata package installed) in the docker compose file for bahmni-lite. The container timezone can be updated by changing the TZ variable in the .env file. The TZ env variable is by default set to Asia/Kolkata.