### PR TITLE
BAH-2962 | Mount sms_token from sms-service to openmrs.

### DIFF
--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -68,6 +68,8 @@ services:
       MAIL_USER: ${MAIL_USER}
       MAIL_PASSWORD: ${MAIL_PASSWORD}
       OMRS_DOCKER_ENV: ${OPENMRS_DOCKER_ENV}
+      OPENMRS_HOST: ${OPENMRS_HOST:?}
+      OPENMRS_PORT: ${OPENMRS_PORT:?}
       OMRS_C3P0_MAX_SIZE: ${OMRS_C3P0_MAX_SIZE}
     #ports:
       # - ${OMRS_DEV_DEBUG_PORT}:${OMRS_DEV_DEBUG_PORT}
@@ -79,6 +81,7 @@ services:
       - 'bahmni-document-images:/home/bahmni/document_images'
       - 'bahmni-clinical-forms:/home/bahmni/clinical_forms'
       - 'configuration_checksums:/openmrs/data/configuration_checksums'
+      - 'sms-tokens:/openmrs/data/sms-tokens'
 
     depends_on:
       - openmrsdb
@@ -308,6 +311,8 @@ services:
       SMS_ORIGINATOR: ${SMS_ORIGINATOR}
       SMS_OPENMRS_HOST: ${OPENMRS_HOST:?}
       SMS_OPENMRS_PORT: ${OPENMRS_PORT:?}
+    volumes:
+      - 'sms-tokens:/tmp/tokens'
 
   atomfeed-console:
     image: bahmni/atomfeed-console:latest
@@ -361,3 +366,4 @@ volumes:
   mart-data:
   metabase-data:
   bahmni-lab-results:
+  sms-tokens:


### PR DESCRIPTION
SMS token which is generated when (script generate-token in)sms-service container starts contains 10 different tokens which will be used to authenticate that requests coming to sms-service are from bahmni related service only.