### PR TITLE
BAH-3450 | Add volume mount for PACS DB data

### DIFF
--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -375,6 +375,7 @@ services:
       PACS_INTEGRATION_DB_PASSWORD: ${PACS_INTEGRATION_DB_PASSWORD:?}
     volumes:
       - '${PWD}/init_pacs_dbs.sh:/docker-entrypoint-initdb.d/init_pacs_dbs.sh'
+      - 'pacsdbdata:/var/lib/postgresql/data'
     logging: *log-config
 
   pacs-simulator:
@@ -461,3 +462,4 @@ volumes:
   sms-token:
   bahmni-queued-reports:
   reportsdbdata:
+  pacsdbdata:


### PR DESCRIPTION
Adds a volume mount for PACS database filesystem.

Co-authored-by: Deepti R [deepti.rawat@thoughtworks.com](mailto:deepti.rawat@thoughtworks.com)
Co-authored-by: Sweety Sharma [sweety.sharma@thoughtworks.com](mailto:sweety.sharma@thoughtworks.com)