### PR TITLE
BAH-3477 | Add. bahmni-mart to reports service profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .cache/
 **/backup-artifacts/*
 **/restore-artifacts/*
+.DS_Store

--- a/bahmni-lite/docker-compose.yml
+++ b/bahmni-lite/docker-compose.yml
@@ -226,6 +226,8 @@ services:
      - martdb
      - openmrsdb
      - openmrs
+     - reportsdb
+     - reports
     volumes:
      - 'bahmni-clinical-forms:/home/bahmni/clinical_forms'
 
@@ -249,7 +251,7 @@ services:
 
   reports:
     image: bahmni/reports:${REPORTS_IMAGE_TAG:?}
-    profiles: ["reports","bahmni-lite"]
+    profiles: ["reports","bahmni-lite","bahmni-mart"]
     environment:
       TZ: ${TZ}
       OPENMRS_DB_HOST: ${OPENMRS_DB_HOST:?}
@@ -274,7 +276,7 @@ services:
   reportsdb:
     platform: linux/amd64
     image: mysql:5.7
-    profiles: ["reports","bahmni-lite"]
+    profiles: ["reports","bahmni-lite","bahmni-mart"]
     environment:
       TZ: ${TZ}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?}


### PR DESCRIPTION
Jira -> [BAH-3477](https://bahmni.atlassian.net/browse/BAH-3477)

In this PR, docker-compose configuration has been updated to ensure both `reports` and `reportsdb` services are brought up concurrently with all the services that are tagged under the `bahmni-mart` profile.