### PR TITLE
Fix. Add command to restart proxy after deployment

### DIFF
--- a/.github/workflows/bahmni_lite_docker_env.yaml
+++ b/.github/workflows/bahmni_lite_docker_env.yaml
@@ -62,6 +62,7 @@ jobs:
                   "git pull -r",
                   "docker compose --env-file .env.dev pull",
                   "'"$command"'",
+                  "docker compose --env-file .env.dev restart proxy",
                   "docker image prune -f"
                 ],
                 "workingDirectory": [

--- a/.github/workflows/bahmni_standard_docker_env.yaml
+++ b/.github/workflows/bahmni_standard_docker_env.yaml
@@ -66,6 +66,7 @@ jobs:
                   "git pull -r",
                   "docker compose --env-file .env.dev pull",
                   "'"$command"'",
+                  "docker compose --env-file .env.dev restart proxy",
                   "docker image prune -f"
                 ],
                 "workingDirectory": [


### PR DESCRIPTION
This PR adds restart command to the deployment workflows to restart proxy service post deployment. This will ensure proxy routing is properly updated with the newly created container's IP addresses.

JIRA Issue: https://bahmni.atlassian.net/browse/BAH-3498