### PR TITLE
BAH-3800 | Add. Workflow To Scan Images

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -1,0 +1,64 @@
+name: Scan Images In Bahmni Namespace
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  scan-images:
+    name: Scan Images In Bahmni Namespace
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date +'%d-%m-%Y')
+          echo "date=$date" >> $GITHUB_OUTPUT
+      - name: Get Scanner Script and Template File
+        run: |
+          curl -o image-scanner.sh https://raw.githubusercontent.com/Bahmni/bahmni-infra-utils/main/image-scanner.sh
+          chmod +x image-scanner.sh
+          curl -o html.tpl https://raw.githubusercontent.com/Bahmni/bahmni-infra-utils/main/html.tpl
+      - name: Scan Images In Bahmni Namespace
+        run: |
+          ./image-scanner.sh
+      - name: Upload Report Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-scan-summary
+          path: container-scanner-reports/bahmni-${{ steps.date.outputs.date }}
+
+  save-scan-summary:
+    name: Save Scan Summary
+    needs: scan-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout security-private repo
+        uses: actions/checkout@v4
+        with:
+          repository: Bahmni/security-reports
+          token: ${{ secrets.BAHMNI_PAT }}
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date +'%d-%m-%Y')
+          echo "date=$date" >> $GITHUB_OUTPUT
+      - name: Download Cluster Summary
+        uses: actions/download-artifact@v4
+        with:
+          name: image-scan-summary
+          path: image-scan-report/${{ steps.date.outputs.date }}
+      - name: Commit and push changes
+        id: auto-commit-action
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[Bahmni Infra] | Add. Image Scan Report ${{ steps.date.outputs.date }}"
+          file_pattern: '*.html'
+          repository: .
+          commit_user_name: Bahmni Infra
+          commit_user_email: infrastructure@bahmni.org
+          commit_author: bahmni-infra <infrastructure@bahmni.org>

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -11,8 +11,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: Checkout security-private repo
         uses: actions/checkout@v4
+        with:
+          repository: Bahmni/security-reports
+          token: ${{ secrets.BAHMNI_PAT }}
       - name: Get current date
         id: date
         run: |
@@ -25,33 +28,7 @@ jobs:
           curl -o html.tpl https://raw.githubusercontent.com/Bahmni/bahmni-infra-utils/main/html.tpl
       - name: Scan Images In Bahmni Namespace
         run: |
-          ./image-scanner.sh
-      - name: Upload Report Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: image-scan-summary
-          path: container-scanner-reports/bahmni-${{ steps.date.outputs.date }}
-
-  save-scan-summary:
-    name: Save Scan Summary
-    needs: scan-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout security-private repo
-        uses: actions/checkout@v4
-        with:
-          repository: Bahmni/security-reports
-          token: ${{ secrets.BAHMNI_PAT }}
-      - name: Get current date
-        id: date
-        run: |
-          date=$(date +'%d-%m-%Y')
-          echo "date=$date" >> $GITHUB_OUTPUT
-      - name: Download Cluster Summary
-        uses: actions/download-artifact@v4
-        with:
-          name: image-scan-summary
-          path: image-scan-report/${{ steps.date.outputs.date }}
+          ./image-scanner.sh bahmni
       - name: Commit and push changes
         id: auto-commit-action
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
JIRA -> [BAH-3800](https://bahmni.atlassian.net/browse/BAH-3800)

In this PR a workflow named "Scan Images In Bahmni Namespace" that performs a comprehensive scan of images within the Bahmni namespace, generates a summary report, and then saves the report in a security-private repository been added. This workflow is a cron job that runs every day.

### Steps in the Workflow

1. **Checkout Repository**: It checks out the current repository using the latest version of the checkout action.
2. **Get Current Date**: The workflow calculates the current date and stores it as an environment variable for use in later steps.
3. **Retrieve Scripts and Template**: The workflow downloads the `image-scanner.sh` script and an HTML template (`html.tpl`) from the specified URL. These files are made executable and will be used for the image scanning process.
4. **Scan Images**: Using the `image-scanner.sh` script, the workflow scans Docker images within the Bahmni namespace and generates a summary report.
5. **Upload Report Artifact**: The generated scan summary is uploaded as an artifact named `image-scan-summary` for the current date.

### Permissions and Security

The workflow grants write permissions to the contents and actions. It uses a personal access token (PAT) `BAHMNI_PAT` stored in secrets for authenticating access to the security-private repo. The workflow is to be granted access to the PAT stored in secrets, before triggering the workflow.