### PR TITLE
BAH-3863 | Refactor. Odoo services to support Odoo 16 as default

### DIFF
--- a/bahmni-standard/.env
+++ b/bahmni-standard/.env
@@ -14,6 +14,10 @@ ODOO_HOST=odoo
 ODOO_PORT=8069
 ODOO_ATOMFEED_USER=admin
 ODOO_ATOMFEED_PASSWORD=admin
+ODOO_10_HOST=odoo-10
+ODOO_10_PORT=8069
+ODOO_10_ATOMFEED_USER=admin
+ODOO_10_ATOMFEED_PASSWORD=admin
 
 # Mail Config Properties Environment Variables
 MAIL_TRANSPORT_PROTOCOL=smtps
@@ -44,7 +48,7 @@ OPENELIS_DB_PASSWORD=postgres
 
 # Odoo Environment Variables
 ODOO_IMAGE_TAG=latest
-ODOO_DB_IMAGE_NAME=bahmni/odoo-10-db:demo-latest
+ODOO_DB_IMAGE_NAME=postgres:16
 ODOO_DB_HOST=odoodb
 ODOO_DB_NAME=odoo
 ODOO_DB_USER=odoo
@@ -52,6 +56,17 @@ ODOO_DB_PASSWORD=odoo
 ODOO_DB_DUMP_PATH=./odoo-db-dump
 EXTRA_ADDONS_PATH=./extra-odoo-addons
 BAHMNI_ODOO_MODULES_PATH=
+
+# Odoo 10 Environment Variables
+ODOO_10_IMAGE_TAG=latest
+ODOO_10_DB_IMAGE_NAME=bahmni/odoo-10-db:demo-latest
+ODOO_10_DB_HOST=odoo-10-db
+ODOO_10_DB_NAME=odoo
+ODOO_10_DB_USER=odoo
+ODOO_10_DB_PASSWORD=odoo
+ODOO_10_DB_DUMP_PATH=./odoo-db-dump
+EXTRA_ADDONS_PATH=./extra-odoo-addons
+BAHMNI_ODOO_10_MODULES_PATH=
 
 # Odoo Connect Environment Variables
 ODOO_CONNECT_IMAGE_TAG=latest

--- a/bahmni-standard/.env
+++ b/bahmni-standard/.env
@@ -53,7 +53,6 @@ ODOO_DB_HOST=odoodb
 ODOO_DB_NAME=odoo
 ODOO_DB_USER=odoo
 ODOO_DB_PASSWORD=odoo
-ODOO_DB_DUMP_PATH=./odoo-db-dump
 EXTRA_ADDONS_PATH=./extra-odoo-addons
 BAHMNI_ODOO_MODULES_PATH=
 
@@ -65,7 +64,7 @@ ODOO_10_DB_NAME=odoo
 ODOO_10_DB_USER=odoo
 ODOO_10_DB_PASSWORD=odoo
 ODOO_10_DB_DUMP_PATH=./odoo-db-dump
-EXTRA_ADDONS_PATH=./extra-odoo-addons
+EXTRA_ODOO_10_ADDONS_PATH=./extra-odoo-10-addons
 BAHMNI_ODOO_10_MODULES_PATH=
 
 # Odoo Connect Environment Variables

--- a/bahmni-standard/.env.dev
+++ b/bahmni-standard/.env.dev
@@ -14,6 +14,10 @@ ODOO_HOST=odoo
 ODOO_PORT=8069
 ODOO_ATOMFEED_USER=admin
 ODOO_ATOMFEED_PASSWORD=admin
+ODOO_10_HOST=odoo-10
+ODOO_10_PORT=8069
+ODOO_10_ATOMFEED_USER=admin
+ODOO_10_ATOMFEED_PASSWORD=admin
 
 # Mail Config Properties Environment Variables
 MAIL_TRANSPORT_PROTOCOL=smtps
@@ -44,7 +48,7 @@ OPENELIS_DB_PASSWORD=postgres
 
 # Odoo Environment Variables
 ODOO_IMAGE_TAG=latest
-ODOO_DB_IMAGE_NAME=bahmni/odoo-10-db:demo-latest
+ODOO_DB_IMAGE_NAME=postgres:16
 ODOO_DB_HOST=odoodb
 ODOO_DB_NAME=odoo
 ODOO_DB_USER=odoo
@@ -52,6 +56,17 @@ ODOO_DB_PASSWORD=odoo
 ODOO_DB_DUMP_PATH=./odoo-db-dump
 EXTRA_ADDONS_PATH=./extra-odoo-addons
 BAHMNI_ODOO_MODULES_PATH=
+
+# Odoo 10 Environment Variables
+ODOO_10_IMAGE_TAG=latest
+ODOO_10_DB_IMAGE_NAME=bahmni/odoo-10-db:demo-latest
+ODOO_10_DB_HOST=odoo-10-db
+ODOO_10_DB_NAME=odoo
+ODOO_10_DB_USER=odoo
+ODOO_10_DB_PASSWORD=odoo
+ODOO_10_DB_DUMP_PATH=./odoo-db-dump
+EXTRA_ADDONS_PATH=./extra-odoo-addons
+BAHMNI_ODOO_10_MODULES_PATH=
 
 # Odoo Connect Environment Variables
 ODOO_CONNECT_IMAGE_TAG=latest

--- a/bahmni-standard/.env.dev
+++ b/bahmni-standard/.env.dev
@@ -53,7 +53,6 @@ ODOO_DB_HOST=odoodb
 ODOO_DB_NAME=odoo
 ODOO_DB_USER=odoo
 ODOO_DB_PASSWORD=odoo
-ODOO_DB_DUMP_PATH=./odoo-db-dump
 EXTRA_ADDONS_PATH=./extra-odoo-addons
 BAHMNI_ODOO_MODULES_PATH=
 
@@ -65,7 +64,7 @@ ODOO_10_DB_NAME=odoo
 ODOO_10_DB_USER=odoo
 ODOO_10_DB_PASSWORD=odoo
 ODOO_10_DB_DUMP_PATH=./odoo-db-dump
-EXTRA_ADDONS_PATH=./extra-odoo-addons
+EXTRA_ODOO_10_ADDONS_PATH=./extra-odoo-10-addons
 BAHMNI_ODOO_10_MODULES_PATH=
 
 # Odoo Connect Environment Variables

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 
   odoo:
     profiles: ["odoo","bahmni-standard"]
-    image: 'bahmni/odoo-10:${ODOO_IMAGE_TAG:?[ERROR]}'
+    image: 'bahmni/odoo-16:${ODOO_IMAGE_TAG:?[ERROR]}'
     ports:
       - '8069:8069'
     volumes:
@@ -86,7 +86,7 @@ services:
       odoodb:
         condition: service_healthy
     environment:
-      HOST: odoodb
+      HOST: ${ODOO_DB_HOST}
       USER: ${ODOO_DB_USER}
       PASSWORD: ${ODOO_DB_PASSWORD}
     logging: *log-config
@@ -96,7 +96,6 @@ services:
     profiles: ["odoo","bahmni-standard"]
     image: '${ODOO_DB_IMAGE_NAME:?[ERROR]}'
     volumes:
-      - '${ODOO_DB_DUMP_PATH}:/resources/db-dump'
       - 'odoodbdata:/var/lib/postgresql/data'
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -h localhost -U odoo']
@@ -113,7 +112,8 @@ services:
     profiles: ["odoo","bahmni-standard"]
     image: 'bahmni/odoo-connect:${ODOO_CONNECT_IMAGE_TAG:?[ERROR]}'
     environment:
-      ODOO_DB_SERVER: odoodb
+      IS_ODOO_16: true
+      ODOO_DB_SERVER: ${ODOO_DB_HOST}
       ODOO_DB_USERNAME: ${ODOO_DB_USER:?}
       ODOO_DB_PASSWORD: ${ODOO_DB_PASSWORD:?}
       OPENMRS_HOST: ${OPENMRS_HOST:?}
@@ -130,6 +130,69 @@ services:
       ODOO_ATOMFEED_PASSWORD: ${ODOO_ATOMFEED_PASSWORD:?}
     depends_on:
       odoodb:
+        condition: service_healthy
+    logging: *log-config
+    restart: ${RESTART_POLICY}
+
+#Serivces for odoo-10. These services are used for backward compatibility with bahmni 0.93
+  odoo-10:
+    profiles: ["odoo-10"]
+    image: 'bahmni/odoo-10:${ODOO_IMAGE_TAG:?[ERROR]}'
+    ports:
+      - '8070:8069'
+    volumes:
+      - odoo10appdata:/var/lib/odoo
+      - ${EXTRA_ADDONS_PATH}:/mnt/extra-addons
+      # # Uncomment the below volume only when you need to modify existing bahmni-addons. Also make sure to update the .env file variable with odoo-modules github repo cloned path.
+      # - ${BAHMNI_ODOO_10_MODULES_PATH}:/opt/bahmni-erp/bahmni-addons
+    depends_on:
+      odoo-10-db:
+        condition: service_healthy
+    environment:
+      HOST: ${ODOO_10_DB_HOST}
+      USER: ${ODOO_10_DB_USER}
+      PASSWORD: ${ODOO_10_DB_PASSWORD}
+    logging: *log-config
+    restart: ${RESTART_POLICY}
+
+  odoo-10-db:
+    profiles: ["odoo-10"]
+    image: '${ODOO_10_DB_IMAGE_NAME:?[ERROR]}'
+    volumes:
+      - '${ODOO_DB_DUMP_PATH}:/resources/db-dump'
+      - 'odoo10dbdata:/var/lib/postgresql/data'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -h localhost -U odoo']
+      interval: 10s
+      timeout: 5s
+    environment:
+      POSTGRES_DB: ${ODOO_10_DB_NAME:?}
+      POSTGRES_PASSWORD: ${ODOO_10_DB_PASSWORD}
+      POSTGRES_USER: ${ODOO_10_DB_USER}
+    logging: *log-config
+    restart: ${RESTART_POLICY}
+
+  odoo-10-connect:
+    profiles: ["odoo-10"]
+    image: 'bahmni/odoo-connect:${ODOO_CONNECT_IMAGE_TAG:?[ERROR]}'
+    environment:
+      ODOO_DB_SERVER: odoo-10-db
+      ODOO_DB_USERNAME: ${ODOO_10_DB_USER:?}
+      ODOO_DB_PASSWORD: ${ODOO_10_DB_PASSWORD:?}
+      OPENMRS_HOST: ${OPENMRS_HOST:?}
+      OPENMRS_PORT: ${OPENMRS_PORT:?}
+      OPENMRS_ATOMFEED_USER: ${OPENMRS_ATOMFEED_USER:?}
+      OPENMRS_ATOMFEED_PASSWORD: ${OPENMRS_ATOMFEED_PASSWORD:?}
+      OPENELIS_HOST: ${OPENELIS_HOST:?}
+      OPENELIS_PORT: ${OPENELIS_PORT:?}
+      OPENELIS_ATOMFEED_USER: ${OPENELIS_ATOMFEED_USER:?}
+      OPENELIS_ATOMFEED_PASSWORD: ${OPENELIS_ATOMFEED_PASSWORD:?}
+      ODOO_HOST: ${ODOO_10_HOST:?}
+      ODOO_PORT: ${ODOO_10_PORT:?}
+      ODOO_ATOMFEED_USER: ${ODOO_10_ATOMFEED_USER:?}
+      ODOO_ATOMFEED_PASSWORD: ${ODOO_10_ATOMFEED_PASSWORD:?}
+    depends_on:
+      odoo-10-db:
         condition: service_healthy
     logging: *log-config
     restart: ${RESTART_POLICY}
@@ -472,6 +535,8 @@ volumes:
   openelisdbdata:
   odoodbdata:
   odooappdata:
+  odoo10dbdata:
+  odoo10appdata:
   openmrs-data:
   openmrsdbdata:
   metabase-data:

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     volumes:
       - odooappdata:/var/lib/odoo
       - ${EXTRA_ADDONS_PATH}:/mnt/extra-addons
-      # # Uncomment the below volume only when you need to modify existing bahmni-addons. Also make sure to update the .env file variable with odoo-modules github repo cloned path.
+      # # Uncomment the below volume only when you need to modify existing bahmni-addons. Also make sure to update the .env file variable with bahmni-odoo-modules github repo cloned path.
       # - ${BAHMNI_ODOO_MODULES_PATH}:/opt/bahmni-erp/bahmni-addons
     depends_on:
       odoodb:
@@ -142,7 +142,7 @@ services:
       - '8070:8069'
     volumes:
       - odoo10appdata:/var/lib/odoo
-      - ${EXTRA_ADDONS_PATH}:/mnt/extra-addons
+      - ${EXTRA_ODOO_10_ADDONS_PATH}:/mnt/extra-addons
       # # Uncomment the below volume only when you need to modify existing bahmni-addons. Also make sure to update the .env file variable with odoo-modules github repo cloned path.
       # - ${BAHMNI_ODOO_10_MODULES_PATH}:/opt/bahmni-erp/bahmni-addons
     depends_on:

--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     profiles: ["odoo-10"]
     image: '${ODOO_10_DB_IMAGE_NAME:?[ERROR]}'
     volumes:
-      - '${ODOO_DB_DUMP_PATH}:/resources/db-dump'
+      - '${ODOO_10_DB_DUMP_PATH}:/resources/db-dump'
       - 'odoo10dbdata:/var/lib/postgresql/data'
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -h localhost -U odoo']


### PR DESCRIPTION
This PR updates the docker compose and .env files of bahmni-standard to have Odoo 16 as the default setup with Bahmni Standard.

Odoo 10 services are still available for implementers to run with Docker, but the profile `odoo-10` needs to be enabled