### PR TITLE
BAH-3515 | Add. Volume mount to persist xml configurations for dcm4chee

### DIFF
--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -430,6 +430,7 @@ services:
       - '11112:11112'
     volumes:
       - 'dcm4chee-archive:/var/lib/bahmni/dcm4chee/server/default/archive'
+      - 'dcm4chee-config:/var/lib/bahmni/dcm4chee/server/default/data/xmbean-attrs'
     logging: *log-config
     restart: ${RESTART_POLICY}
 
@@ -565,3 +566,4 @@ volumes:
   bahmni-queued-reports:
   reportsdbdata:
   pacsdbdata:
+  dcm4chee-config:


### PR DESCRIPTION
This PR adds a volume mount to DCM4CHEE service to persist configurations made using jmx-console.

JIRA: https://bahmni.atlassian.net/browse/BAH-3515
