### PR TITLE
BAH-4054 | Add. Volume to persist Odoo conf file

### DIFF
--- a/bahmni-standard/docker-compose.yml
+++ b/bahmni-standard/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - odooappdata:/var/lib/odoo
       - ${EXTRA_ADDONS_PATH}:/mnt/extra-addons
       - odoofilestore:/var/lib/odoo/filestore
+      - odooconfig:/etc/odoo
       # # Uncomment the below volume only when you need to modify existing bahmni-addons. Also make sure to update the .env file variable with bahmni-odoo-modules github repo cloned path.
       # - ${BAHMNI_ODOO_MODULES_PATH}:/opt/bahmni-erp/bahmni-addons
     depends_on:
@@ -610,6 +611,7 @@ volumes:
   odoodbdata:
   odooappdata:
   odoofilestore:
+  odooconfig:
   odoo10dbdata:
   odoo10appdata:
   openmrs-data:


### PR DESCRIPTION
This PR adds a new named volume to persist the configuration file of Odoo located at `\etc\odoo` of the Odoo service. This is crucial for persisting the master password of Odoo