### PR TITLE
BAH-5025 | Add TruffleHog secret scanning to CI

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     branches: [main, master]
-  schedule:
-    - cron: '41 3 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,32 @@
+name: TruffleHog Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '41 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # TruffleHog diffs commit ranges, so the full history must be present.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Secret scan
+        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b  # v3.97.1
+        with:
+          # ghcr.io/trufflesecurity/trufflehog image tag; bump with the action pin above.
+          version: 3.97.1
+          # Only credentials TruffleHog confirmed live against the provider's API
+          # fail the job. Unverified matches (vendored test fixtures, .env
+          # placeholders, strings inside .jar/.zip/.omod archives) are ignored.
+          extra_args: --results=verified


### PR DESCRIPTION
## Summary

Adds `.github/workflows/trufflehog.yml`, a TruffleHog OSS secret-scanning workflow. Part of BAH-5025, rolled out identically across the 29 repos tracked by the Repo Security & Practices dashboard.

Jira: https://bahmni.atlassian.net/browse/BAH-5025

## Why

GitHub native secret scanning and push protection are already enabled here and report 0 open alerts. On the GitHub Free plan that is the ceiling. The two settings that would close the remaining gap are paid:

- `secret_scanning_non_provider_patterns` (generic secrets: database connection strings, private keys, passwords) requires GitHub Team or Enterprise Cloud with Secret Protection.
- `secret_scanning_validity_checks` (is the credential actually live?) is documented as available only on GitHub Team or Enterprise with Secret Protection.

TruffleHog OSS covers both at no cost, over full git history. It is distinct from the existing CodeQL and Semgrep workflows, which analyse code at HEAD for vulnerable patterns and neither read history nor verify credentials.

## Cost and build impact

- $0. This repo is public, and GitHub Actions on standard runners is free for public repositories. No account or token needed; the scan runs on the runner.
- Own parallel workflow, so nothing is added to the critical path.
- `--results=verified` means only credentials TruffleHog confirmed live against the provider's API fail the job. A full-history scan of all 29 repos found 0 verified secrets, and the 25 unverified matches (vendored `node_modules` fixtures, `.env` placeholders, strings inside `.jar`/`.zip`/`.omod` archives) are ignored by this setting.
- Not wired into required-status-checks, so it cannot block a merge.

## Test plan

- [ ] `TruffleHog Secret Scan` workflow runs on this PR and completes green
- [ ] Both actions are pinned to commit SHAs (keeps `sc_actions_pinned` passing)
- [ ] Workflow declares only `contents: read` (keeps `sc_token_permissions` passing)
